### PR TITLE
Implement DispositionCode#success?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ NCS Navigator MDES Module history
 0.7.1
 -----
 
+- Add DispositionCode#success? to partition activities into
+  successfully and unsuccesfully completed (e.g. canceled) sets.
+  (#16)
+
 0.7.0
 -----
 

--- a/ci-exec.sh
+++ b/ci-exec.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -xe
 
-BUNDLER_VERSION=1.1.rc
+BUNDLER_VERSION=1.1.5
 GEMSET=ncs_mdes
 
 if [ -z $CI_RUBY ]; then

--- a/lib/ncs_navigator/mdes/disposition_code.rb
+++ b/lib/ncs_navigator/mdes/disposition_code.rb
@@ -24,6 +24,15 @@ module NcsNavigator::Mdes
     end
 
     ##
+    # If the code's final category signifies successful completion, returns
+    # true; otherwise, returns false.
+    #
+    # @return [Boolean]
+    def success?
+      final_category.to_s.start_with?('Complete')
+    end
+
+    ##
     # Provides a briefer inspection for cleaner IRB use.
     #
     # @return [String]

--- a/spec/ncs_navigator/mdes/disposition_code_spec.rb
+++ b/spec/ncs_navigator/mdes/disposition_code_spec.rb
@@ -1,0 +1,39 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+
+module NcsNavigator::Mdes
+  describe DispositionCode do
+    let(:code) { DispositionCode.new({}) }
+
+    describe '#success?' do
+      describe 'if #final_category starts with "Complete"' do
+        before do
+          code.final_category = 'Complete Interview'
+        end
+
+        it 'returns true' do
+          code.should be_success
+        end
+      end
+
+      describe 'if #final_category does not start with "Complete"' do
+        before do
+          code.final_category = 'Eligible Non-Interview'
+        end
+
+        it 'returns false' do
+          code.should_not be_success
+        end
+      end
+
+      describe 'if #final_category is nil' do
+        before do
+          code.final_category = nil
+        end
+
+        it 'returns false' do
+          code.should_not be_success
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
There's some places in Cases where we need to know whether an event has been completed or canceled.   This status is determined by the event's disposition code.

There is no single disposition code that means "success" or "canceled"; rather, there's many such disposition codes, and the codes that mean "success" or "canceled" differ between categories.

However, each disposition code has an attribute called "final category".  Here's a sampling of values:
- Complete
- Complete Interview
- Eligible Non-Recruit
- Not Eligible

We can therefore probably get away with this definition:

``` ruby
def success?
  final_category =~ /^Complete/
end
```

Implement this.
